### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/Secrets Sync Action.yml
+++ b/.github/Secrets Sync Action.yml
@@ -1,2 +1,2 @@
 - name: Secrets Sync Action
-  uses: google/secrets-sync-action@v1.4.1
+  uses: jpoehnelt/secrets-sync-action@v1.4.1


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.